### PR TITLE
Make pytest-vnet not enabled by default, require ini option to enable

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+netvm_required = true

--- a/pytest_vnet/__init__.py
+++ b/pytest_vnet/__init__.py
@@ -14,8 +14,6 @@ from typing import Optional
 
 from pathlib import Path
 
-from tempfile import TemporaryFile, TemporaryDirectory
-
 from ._utils import NonZeroExitcode, stream_run, background_run
 
 
@@ -26,7 +24,7 @@ PYTHON_VERSION = f"{sys.version_info[0]}."\
     f"{sys.version_info[2]}"
 
 
-run_in_netvm = pytest.mark.RUN_IN_NETVM
+run_in_netvm = pytest.mark.run_in_netvm
 
 
 def install_python_container(target_version: Optional[str] = None) -> None:
@@ -117,17 +115,6 @@ def initiate_container(target_version: Optional[str] = None) -> Container:
                         read_only=True
                     )
                 )
-
-    # with TemporaryDirectory() as tmpdirname:
-    #     with open(f"{tmpdirname}/{run_target.name}", "w") as tmp_run:
-    #         with open(run_target, "r") as src:
-    #             # Patch up target file, insert sys.path appends on top
-    #             tmp_run.write("import sys\n")
-    #             for path in sys_path_targets:
-    #                 tmp_run.write(f"sys.path.append(\"{path}\")\n")
-
-    #             # Write rest of the file
-    #             tmp_run.write(src.read())
 
     # Instance container
     cont = DOCKERC.containers.create(

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,4 +1,3 @@
-
 from pytest_vnet import run_in_netvm
 
 @run_in_netvm

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -2,3 +2,7 @@
 
 def test_assert_true():
 	assert True
+
+def test_assert_for_true():
+	for i in range(5):
+		assert True


### PR DESCRIPTION
Closes #6 

Also added run_in_netvm test marker info (shows when calling pytest with `--markers`).